### PR TITLE
Fix memory leak - mismatch alloc/dealloc

### DIFF
--- a/girepository/girepository.c
+++ b/girepository/girepository.c
@@ -177,7 +177,7 @@ init_globals (void)
             }
 
           /* ownership of the array content was passed to the list */
-          g_free (custom_dirs);
+          g_strfreev (custom_dirs);
         }
 
       libdir = GOBJECT_INTROSPECTION_LIBDIR;


### PR DESCRIPTION
Please check :
Refer - https://developer.gnome.org/glib/stable/glib-String-Utility-Functions.html#g-strsplit
Returns
a newly-allocated NULL-terminated array of strings. Use g_strfreev() to free it.