### PR TITLE
Add option to make .gir files installation paths configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,10 @@ GIR_SUFFIX="gir-1.0"
 AC_SUBST(GIR_SUFFIX)
 AC_DEFINE_UNQUOTED(GIR_SUFFIX, "$GIR_SUFFIX", [Name of the gir directory])
 
-GIR_DIR="$EXPANDED_DATADIR/$GIR_SUFFIX"
+AC_ARG_WITH(gir-dir-prefix,
+		AS_HELP_STRING([--with-gir-dir-prefix], [Director prefix for gir installation]),
+		[GIR_DIR_PREFIX="$withval"], [GIR_DIR_PREFIX="$EXPANDED_DATADIR"])
+GIR_DIR="$GIR_DIR_PREFIX/$GIR_SUFFIX"
 AC_SUBST(GIR_DIR)
 AC_DEFINE_UNQUOTED(GIR_DIR, "$GIR_DIR", [Director prefix for gir installation])
 

--- a/gir/meson.build
+++ b/gir/meson.build
@@ -34,7 +34,6 @@ gir_files = [
 ]
 
 typelibdir = join_paths(get_option('libdir'), 'girepository-1.0')
-girdir = join_paths(get_option('datadir'), 'gir-1.0')
 install_data(gir_files, install_dir: girdir)
 
 scanner_command = [

--- a/gobject-introspection-1.0.pc.in
+++ b/gobject-introspection-1.0.pc.in
@@ -10,7 +10,7 @@ g_ir_scanner=${bindir}/g-ir-scanner
 g_ir_compiler=${bindir}/g-ir-compiler@EXEEXT@
 g_ir_generate=${bindir}/g-ir-generate@EXEEXT@
 gidatadir=${datadir}/gobject-introspection-1.0
-girdir=${datadir}/gir-1.0
+girdir=@GIR_DIR@
 typelibdir=${libdir}/girepository-1.0
 
 Cflags: -I${includedir}/gobject-introspection-1.0 @FFI_PC_CFLAGS@

--- a/gobject-introspection-no-export-1.0.pc.in
+++ b/gobject-introspection-no-export-1.0.pc.in
@@ -9,7 +9,7 @@ includedir=@includedir@
 g_ir_scanner=${bindir}/g-ir-scanner
 g_ir_compiler=${bindir}/g-ir-compiler@EXEEXT@
 g_ir_generate=${bindir}/g-ir-generate@EXEEXT@
-girdir=${datadir}/gir-1.0
+girdir=@GIR_DIR@
 typelibdir=${libdir}/girepository-1.0
 
 Cflags: -I${includedir}/gobject-introspection-1.0 @FFI_PC_CFLAGS@

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,12 @@ python = pymod.find_installation(get_option('python'))
 cc = meson.get_compiler('c')
 config = configuration_data()
 config.set_quoted('GIR_SUFFIX', 'gir-1.0')
-config.set_quoted('GIR_DIR', join_paths(get_option('prefix'), get_option('datadir'), 'gir-1.0'))
+gir_dir_prefix = get_option('gir-dir-prefix')
+if gir_dir_prefix == ''
+    gir_dir_prefix = get_option('datadir')
+endif
+girdir = join_paths(get_option('prefix'), gir_dir_prefix, 'gir-1.0')
+config.set_quoted('GIR_DIR', girdir)
 config.set_quoted('GOBJECT_INTROSPECTION_LIBDIR', join_paths(get_option('prefix'), get_option('libdir')))
 
 foreach type : ['char', 'short', 'int', 'long']
@@ -93,6 +98,7 @@ pkgconfig_conf.set('libdir', join_paths('${prefix}', get_option('libdir')))
 pkgconfig_conf.set('datarootdir', join_paths('${prefix}', get_option('datadir')))
 pkgconfig_conf.set('datadir', '${datarootdir}')
 pkgconfig_conf.set('includedir', join_paths('${prefix}', get_option('includedir')))
+pkgconfig_conf.set('GIR_DIR', join_paths('${prefix}', gir_dir_prefix, 'gir-1.0'))
 if host_system == 'windows' or host_system == 'cygwin'
   pkgconfig_conf.set('EXEEXT', '.exe')
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,3 +21,7 @@ option('cairo-libname', type: 'string',
 option('python', type: 'string', value: 'python3',
   description: 'Path or name of the Python interpreter to build for'
 )
+
+option('gir-dir-prefix', type: 'string',
+  description: 'Intermediate prefix for gir installation under ${prefix}'
+)


### PR DESCRIPTION
.gir files are arch related which contain such as lengths of pointers                                                                                           
that they are different for 64 and 32 bits target. It causes install                                                                                            
file conflicts for multilib when intall gobject-introspection and                                                                                               
lib32-gobject-introspection both.

Add options for both configure.ac and meson to make make installation paths of .gir files configurable.